### PR TITLE
.NET 3.5 support

### DIFF
--- a/MonoMod.csproj
+++ b/MonoMod.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MonoMod</RootNamespace>
     <AssemblyName>MonoMod</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,19 +30,16 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="Mono.Cecil">
+      <HintPath>packages\Mono.Cecil.0.10.0-beta4\lib\net35\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>packages\Mono.Cecil.0.10.0-beta4\lib\net35\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>packages\Mono.Cecil.0.10.0-beta4\lib\net35\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoMod\DebugIL\DebugILGeneratorExt.cs" />
@@ -75,6 +73,7 @@
     <Compile Include="MonoMod\Modifiers\MonoModBlacklisted.cs" />
     <Compile Include="MonoMod\Modifiers\MonoModEnumReplace.cs" />
     <Compile Include="MonoMod\Modifiers\MonoModInline.cs" />
+    <Compile Include="MonoMod\NET40Shim.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/MonoMod/InlineRT/MMILRT.cs
+++ b/MonoMod/InlineRT/MMILRT.cs
@@ -1,6 +1,7 @@
 ﻿using Mono.Cecil;
 using StringInject;
 using System;
+using MonoMod.NET40Shim;
 
 namespace MonoMod.InlineRT {
     public static partial class MMILRT {

--- a/MonoMod/MonoModExt.cs
+++ b/MonoMod/MonoModExt.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using MonoMod.NET40Shim;
 
 namespace MonoMod {
 

--- a/MonoMod/MonoModder.cs
+++ b/MonoMod/MonoModder.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using MonoMod.NET40Shim;
 
 namespace MonoMod {
     public class MonoModder : IDisposable {
@@ -150,7 +151,9 @@ namespace MonoMod {
                     }
                     if (os.Contains("win")) {
                         // C:\Windows\Microsoft.NET\assembly\GAC_MSIL\System.Xml
-                        _GACPath = Path.Combine(Environment.GetEnvironmentVariable("windir"), "Microsoft.NET", "assembly", "GAC_MSIL");
+                        _GACPath = Path.Combine(Environment.GetEnvironmentVariable("windir"), "Microsoft.NET");
+                        _GACPath = Path.Combine(_GACPath, "assembly");
+                        _GACPath = Path.Combine(_GACPath, "GAC_MSIL");
 
                         /*} else if (os.Contains("mac") || os.Contains("osx")) {
                         // TODO: Test GAC path for Mono on Mac
@@ -181,7 +184,9 @@ namespace MonoMod {
                         which.CancelOutputRead();
 
                         _GACPath = Directory.GetParent(whichOutputBuilder.ToString().Trim()).Parent.FullName;
-                        _GACPath = Path.Combine(_GACPath, "lib", "mono", "gac");
+                        _GACPath = Path.Combine(_GACPath, "lib");
+                        _GACPath = Path.Combine(_GACPath, "mono");
+                        _GACPath = Path.Combine(_GACPath, "gac");
                     }
                 }
 

--- a/MonoMod/NET40Shim.cs
+++ b/MonoMod/NET40Shim.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace MonoMod.NET40Shim {
+#if !MONOMOD_NET40
+    // http://stackoverflow.com/a/7122209
+    public static class Tuple {
+        public static Tuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) {
+            return new Tuple<T1, T2>(item1, item2);
+        }
+    }
+
+    [DebuggerDisplay("Item1={Item1};Item2={Item2}")]
+    public class Tuple<T1, T2> : IFormattable {
+        public T1 Item1 { get; private set; }
+        public T2 Item2 { get; private set; }
+
+        public Tuple(T1 item1, T2 item2) {
+            Item1 = item1;
+            Item2 = item2;
+        }
+
+        #region Optional - If you need to use in dictionaries or check equality
+        private static readonly IEqualityComparer<T1> Item1Comparer = EqualityComparer<T1>.Default;
+        private static readonly IEqualityComparer<T2> Item2Comparer = EqualityComparer<T2>.Default;
+
+        public override int GetHashCode() {
+            var hc = 0;
+            if (!object.ReferenceEquals(Item1, null))
+                hc = Item1Comparer.GetHashCode(Item1);
+            if (!object.ReferenceEquals(Item2, null))
+                hc = (hc << 3) ^ Item2Comparer.GetHashCode(Item2);
+            return hc;
+        }
+        public override bool Equals(object obj) {
+            var other = obj as Tuple<T1, T2>;
+            if (object.ReferenceEquals(other, null))
+                return false;
+            else
+                return Item1Comparer.Equals(Item1, other.Item1) && Item2Comparer.Equals(Item2, other.Item2);
+        }
+        #endregion
+
+        #region Optional - If you need to do string-based formatting
+        public override string ToString() { return ToString(null, CultureInfo.CurrentCulture); }
+        public string ToString(string format, IFormatProvider formatProvider) {
+            return string.Format(formatProvider, format ?? "{0},{1}", Item1, Item2);
+        }
+        #endregion
+    }
+
+    // http://stackoverflow.com/a/4108907
+    public static class EnumExt {
+        /// <summary>
+        /// Check to see if a flags enumeration has a specific flag set.
+        /// </summary>
+        /// <param name="variable">Flags enumeration to check</param>
+        /// <param name="value">Flag to check for</param>
+        /// <returns></returns>
+        public static bool HasFlag(this Enum variable, Enum value) {
+            if (variable == null)
+                return false;
+
+            if (value == null)
+                throw new ArgumentNullException("value");
+
+            // Not as good as the .NET 4 version of this function, but should be good enough
+            if (!Enum.IsDefined(variable.GetType(), value)) {
+                throw new ArgumentException(string.Format(
+                    "Enumeration type mismatch.  The flag is of type '{0}', was expecting '{1}'.",
+                    value.GetType(), variable.GetType()));
+            }
+
+            ulong num = Convert.ToUInt64(value);
+            return ((Convert.ToUInt64(variable) & num) == num);
+
+        }
+    }
+#endif
+}

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.10.0-beta4" targetFramework="net40" />
+  <package id="Mono.Cecil" version="0.10.0-beta4" targetFramework="net40" requireReinstallation="True" />
 </packages>


### PR DESCRIPTION
Includes shim for .NET 4.0 Tuple type and HasFlag method on Enum (under the MonoMod.NET40Shim namespace), can be disabled by defining the MONOMOD_NET40 symbol.