### PR TITLE
Attempt to fix EventDefinition and EventReference

### DIFF
--- a/MonoMod/MonoModExt.cs
+++ b/MonoMod/MonoModExt.cs
@@ -653,12 +653,21 @@ namespace MonoMod {
             return null;
         }
 
+        public static EventDefinition FindEvent(this TypeDefinition type, string name)
+        {
+            foreach (EventDefinition eventDef in type.Events)
+                if (eventDef.Name == name) return eventDef;
+            return null;
+        }
+
         public static bool HasMethod(this TypeDefinition type, MethodDefinition method)
             => type.FindMethod(method.GetFindableID(withType: false)) != null;
         public static bool HasProperty(this TypeDefinition type, PropertyDefinition prop)
             => type.FindProperty(prop.Name) != null;
         public static bool HasField(this TypeDefinition type, FieldDefinition field)
             => type.FindField(field.Name) != null;
+        public static bool HasEvent(this TypeDefinition type, EventDefinition eventDef)
+            => type.FindEvent(eventDef.Name) != null;
 
         public static void SetPublic(this IMetadataTokenProvider mtp, bool p) {
             if (mtp is TypeReference) ((TypeReference) mtp).SafeResolve()?.SetPublic(p);

--- a/MonoMod/MonoModder.cs
+++ b/MonoMod/MonoModder.cs
@@ -1296,8 +1296,9 @@ namespace MonoMod {
                 (addMethod = PatchMethod(targetType, adder)) != null)
             {
                 targetEvent.AddMethod = addMethod;
+                /* Old code that would add the base attributes to the add method.  Causes weird behavior.
                 foreach (CustomAttribute attrib in srcEvent.CustomAttributes)
-                    addMethod.CustomAttributes.Add(attrib.Clone());
+                    addMethod.CustomAttributes.Add(attrib.Clone()); */
                 propMethods?.Add(adder);
             }
 
@@ -1306,8 +1307,9 @@ namespace MonoMod {
                 (addMethod = PatchMethod(targetType, remover)) != null)
             {
                 targetEvent.RemoveMethod = addMethod;
+                /* Old code that would add the base attributes to the remove method.  Causes weird behavior.
                 foreach (CustomAttribute attrib in srcEvent.CustomAttributes)
-                    addMethod.CustomAttributes.Add(attrib.Clone());
+                    addMethod.CustomAttributes.Add(attrib.Clone());*/
                 propMethods?.Add(remover);
             }
 

--- a/MonoMod/MonoModder.cs
+++ b/MonoMod/MonoModder.cs
@@ -1219,10 +1219,8 @@ namespace MonoMod {
         public virtual void PatchEvent(TypeDefinition targetType, EventDefinition srcEvent, HashSet<MethodDefinition> propMethods = null)
         {
             MethodDefinition addMethod;
-            Log($"Patching {targetType.Name}.{srcEvent.Name}");
             EventDefinition targetEvent = targetType.FindEvent(srcEvent.Name);
             string backingName = $"<{srcEvent.Name}>__BackingField";
-            Log(backingName);
             FieldDefinition backing = srcEvent.DeclaringType.FindField(backingName);
             FieldDefinition targetBacking = targetType.FindField(backingName);
 


### PR DESCRIPTION
Initial attempt at fixing #19.  Seems to work when the target type doesn't have an existing event, not sure if it will work on overriding.  Other thing that might be broken is attribute duplication.  Not sure why, but it doesn't seem to break anything.