### PR TITLE
Improve aarch64 comments

### DIFF
--- a/MonoMod.RuntimeDetour/Platforms/Native/DetourNativeARMPlatform.cs
+++ b/MonoMod.RuntimeDetour/Platforms/Native/DetourNativeARMPlatform.cs
@@ -101,10 +101,9 @@ namespace MonoMod.RuntimeDetour.Platforms {
                     break;
 
                 case DetourType.AArch64:
-                    // FIXME: This fails on mono.
                     // PC isn't available on arm64.
                     // We need to burn a register and branch instead.
-                    // LDR X15, #8
+                    // LDR X15, .+8
                     detour.Method.Write(ref offs, (byte) 0x4F);
                     detour.Method.Write(ref offs, (byte) 0x00);
                     detour.Method.Write(ref offs, (byte) 0x00);


### PR DESCRIPTION
Remove FIXME (due to it being fixed), and use `.+8` instead of `#8` (I'm unsure if they're equivalent, but `.+8` was used when assembling and `#8` reads as an absolute address).