### PR TITLE
Fix generic parameter constraints in added types linked to wrong module

### DIFF
--- a/MonoMod/MonoModder.cs
+++ b/MonoMod/MonoModder.cs
@@ -994,7 +994,7 @@ namespace MonoMod {
             TypeDefinition newType = new TypeDefinition(type.Namespace, type.Name, type.Attributes, type.BaseType);
 
             foreach (GenericParameter genParam in type.GenericParameters)
-                newType.GenericParameters.Add(genParam.Clone());
+                newType.GenericParameters.Add(genParam.Clone().Relink(Relinker, newType));
 
             foreach (InterfaceImplementation interf in type.Interfaces)
                 newType.Interfaces.Add(interf);


### PR DESCRIPTION
Generic parameter constraints in types that get added from the mod modules stay linked to the mod module. This PR relinks them while adding the type to the target module.